### PR TITLE
Feat/system messaging

### DIFF
--- a/code-pwa/css/ai-manager.css
+++ b/code-pwa/css/ai-manager.css
@@ -557,6 +557,41 @@ ui-tabbar.tabs-inverted[slim] > ui-tab-item[active] {
 
 /* ... (rest of CSS) ... */
 
+@keyframes sticky-fade-out {
+  0%, 90% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.system-message-sticky-fade {
+	position: absolute;
+	bottom: 0; /* Stick to the top of the conversation-area, below the file bar */
+	z-index: 3; /* Ensure it's above other chat content */
+	border: 1px solid var(--theme);
+	background: var(--themeDark);
+	color: var(--light);
+	animation: sticky-fade-out 5s linear forwards;
+	box-shadow: 0 5px 5px rgba(0, 0, 0, 0.15); /* Add a subtle shadow to lift it off the content */
+	padding:0px;
+
+	padding: 0px;
+	left: 8px;
+	right: 8px;
+}
+
+/*.system-message-sticky-fade {*/
+/*    position: sticky;*/
+/*    bottom: 130px;*/
+/*    border: 1px solid var(--theme);*/
+/*    background: var(--themeDark);*/
+/*    color: var(--light);*/
+    /* animation: sticky-fade-out 10s linear forwards; */
+/*    box-shadow: 0 5px 5px rgba(0, 0, 0, 0.15);*/
+/*}*/
+
 /* Styles for the new in-thread context stale notice */
 .context-stale-notice {
     display: flex;

--- a/code-pwa/css/ai-manager.css
+++ b/code-pwa/css/ai-manager.css
@@ -459,19 +459,12 @@ button:disabled,
     max-width: 150px; 
 }
 
-.context-stale-notice {
-    background-color: var(--dark); 
-    color: #fff; 
-    padding: 6px;
-    display: flex;
-    justify-content: space-between; 
-    align-items: center;
-    gap: 6px; 
-    z-index: 1000; 
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2); 
-    border-radius: 5px; 
-    border: 1px solid var(--theme);
-	margin: 8px 0; /* Add margin to separate from prompt area */
+.ai-file-context-bar {
+	flex-wrap: wrap;
+	gap: 6px;
+	padding: 6px 8px;
+	max-height: 150px; /* Limit height and allow scrolling if needed */
+	overflow-y: auto;
 }
 
 .ai-filebar-container {
@@ -484,13 +477,6 @@ button:disabled,
 	flex-direction: column;
 }
 
-.ai-file-context-bar {
-	flex-wrap: wrap;
-	gap: 6px;
-	padding: 6px 8px;
-	max-height: 150px; /* Limit height and allow scrolling if needed */
-	overflow-y: auto;
-}
 
 .ai-filebar-container > .progress-bar {
 	width: calc(100% - 16px); /* Match padding of file-context-bar */
@@ -498,15 +484,6 @@ button:disabled,
 	height: 6px;
 	background-color: var(--themeDark);
 	border-radius: 4px;
-}
-
-
-.context-stale-notice .message {
-    flex-grow: 1; 
-    text-align: center;
-}
-.context-stale-notice button {
-    padding: 4px 10px;
 }
 
 .button-container {
@@ -579,3 +556,40 @@ ui-tabbar.tabs-inverted[slim] > ui-tab-item[active] {
 }
 
 /* ... (rest of CSS) ... */
+
+/* Styles for the new in-thread context stale notice */
+.context-stale-notice {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px; /* Space between message and button group */
+    border: 1px solid var(--theme); /* Highlight it */
+    font-style: normal; /* Override system-message-block italic */
+    text-align: center;
+}
+
+.system-message-block + .system-message-block.context-stale-notice {
+	margin-top:0px;
+}
+
+.context-stale-notice .button-group {
+    display: flex;
+    gap: 8px;
+}
+
+/* Style the buttons to look consistent */
+.context-stale-notice button {
+    padding: 6px 12px;
+    border-radius: var(--borderRadius);
+    cursor: pointer;
+    border: 1px solid var(--border-color);
+    background-color: var(--low);
+    color: var(--button-text-color);
+    font-size: 0.9em;
+}
+.context-stale-notice .update-button {
+    background-color: var(--theme);
+    border-color: var(--theme);
+    color: var(--light);
+}
+.context-stale-notice button:hover { filter: brightness(1.2); }

--- a/code-pwa/css/ai-manager.css
+++ b/code-pwa/css/ai-manager.css
@@ -601,6 +601,13 @@ ui-tabbar.tabs-inverted[slim] > ui-tab-item[active] {
     border: 1px solid var(--theme); /* Highlight it */
     font-style: normal; /* Override system-message-block italic */
     text-align: center;
+    /* New styles for sticky behavior */
+    position: sticky;
+    bottom: 0;
+    z-index: 4; /* Above other messages */
+    background-color: var(--dark); /* Solid background to obscure content behind it */
+    box-shadow: 0 -5px 10px rgba(0,0,0,0.2); /* Shadow on top to lift it from the content */
+    padding: 8px 16px; /* Ensure consistent padding */
 }
 
 .system-message-block + .system-message-block.context-stale-notice {

--- a/code-pwa/js/ai-manager-history.mjs
+++ b/code-pwa/js/ai-manager-history.mjs
@@ -62,14 +62,15 @@ class AIManagerHistory {
 	/**
 	 * Adds a message object to the active session's history and re-renders the UI.
 	 * @param {Object} messageObject - The message to add (e.g., {type: "system_message", content: "..."}).
+	 * @param {boolean} [autoScroll=true] - Whether to automatically scroll to the bottom.
 	 */
-	addMessage(messageObject) {
+	addMessage(messageObject, autoScroll = true) {
 		if (this.manager.activeSession) {
 			this.manager.activeSession.messages.push(messageObject);
 			this.manager.activeSession.lastModified = Date.now();
 			this.render(); // Re-render to show the new message
 			// Scroll to the bottom of the conversation area to make the new message visible
-			if (this.conversationArea) {
+			if (this.conversationArea && autoScroll) {
 				this.conversationArea.scrollTop = this.conversationArea.scrollHeight;
 			}
 			this.manager._dispatchContextUpdate("add_message", { messageType: messageObject.type });

--- a/code-pwa/js/ai-manager-history.mjs
+++ b/code-pwa/js/ai-manager-history.mjs
@@ -217,6 +217,10 @@ class AIManagerHistory {
 				element.addEventListener('animationend', () => {
 					element.classList.remove('system-message-sticky-fade');
 				}, { once: true });
+				// Also add a click listener to dismiss the notice immediately.
+				element.addEventListener('click', () => {
+					element.classList.remove('system-message-sticky-fade');
+				}, { once: true });
 			}
 		}
 

--- a/code-pwa/js/ai-manager.mjs
+++ b/code-pwa/js/ai-manager.mjs
@@ -96,7 +96,7 @@ class AIManager {
                 type: "system_message",
                 content: `Error initializing AI provider (${this.aiProvider}). Please check your settings. Details: ${error.message}`,
                 timestamp: Date.now(),
-            });
+            }, false);
             // Ensure UI is not blocked
             this._isProcessing = false;
             this._setButtonsDisabledState(false);
@@ -170,7 +170,7 @@ class AIManager {
 					type: 'system_message',
 					content: `**${fileMessage.filename}** removed from this context.`,
 					timestamp: Date.now()
-				});
+				}, false);
 			}
 			// Proceed with the deletion
 			this.historyManager._handleDeleteFileContextItem(fileId);
@@ -520,7 +520,7 @@ class AIManager {
 								? `Current model: **${this.ai.config.model}**`
 								: `Please configure the provider settings.`),
 					timestamp: Date.now()
-				});
+				}, false);
 			} catch (error) {
 				console.error("AIManager: Error initializing new AI provider during switch:", error);
 				// Inform user about the error, but don't re-throw to keep UI interactive
@@ -528,7 +528,7 @@ class AIManager {
 					type: "system_message", // System message for the user
 					content: `Error switching to ${this.aiProvider} provider. Check settings. Details: ${error.message}`,
 					timestamp: Date.now()
-				});
+				}, false);
 			} finally {
 				// Always re-render settings form to reflect new AI's options
 				this._renderSettingsForm(); 
@@ -677,7 +677,7 @@ class AIManager {
 						type: "system_message",
 						content: messageContent,
 						timestamp: Date.now()
-					});
+					}, false);
 					this._dispatchContextUpdate("settings_save_success");
                     this._setButtonsDisabledState(this._isProcessing); // Re-evaluate button state on success
 				},
@@ -1004,7 +1004,7 @@ class AIManager {
                 type: "system_message",
                 content: `AI is not configured or no active session. Please set up your AI provider in the settings or create a new chat.`,
                 timestamp: Date.now(),
-            });
+            }, false);
             this._dispatchContextUpdate("generation_error_not_configured");
             this._isProcessing = false;
             this._setButtonsDisabledState(false);
@@ -1205,7 +1205,7 @@ class AIManager {
 					type: "system_message",
 					content: `Files added to context: ${fileNames}.`,
 					timestamp: Date.now(),
-				});
+				}, false);
 			}
 	
 			// Update lastModified timestamp for the session
@@ -1405,7 +1405,7 @@ class AIManager {
                             type: "system_message",
                             content: `Diff successfully applied to **${targetPath}**. Remember to save the file.`,
                             timestamp: Date.now(),
-                        }); // Auto-scroll is now automatically suppressed for system messages
+                        }, false); // Auto-scroll is now automatically suppressed for system messages
                     }
                 });
                 buttonContainer.append(applyDiffButton);
@@ -1480,7 +1480,8 @@ class AIManager {
 		if (changesMade) {
 			this.activeSession.messages = updatedMessages;
 			this.activeSession.lastModified = Date.now(); // Update last modified timestamp
-			this.historyManager.render(); // Re-render the UI
+			// Just update the file bar, which is the only visual representation of file context.
+			this.historyManager.populateFileBar();
 			this._dispatchContextUpdate("context_files_updated"); // Dispatch event
 		}
 	}

--- a/code-pwa/js/ai-manager.mjs
+++ b/code-pwa/js/ai-manager.mjs
@@ -380,7 +380,6 @@ class AIManager {
 		this.contextStaleNotice = this._createContextStaleNoticeElement();
 		this.contextStaleNotice.querySelector(".message").innerHTML = this.md.render(message);
 		this.conversationArea.append(this.contextStaleNotice);
-		this.conversationArea.scrollTop = this.conversationArea.scrollHeight;
 	}
 
 	_hideContextStaleNotice() {
@@ -1406,7 +1405,7 @@ class AIManager {
                             type: "system_message",
                             content: `Diff successfully applied to **${targetPath}**. Remember to save the file.`,
                             timestamp: Date.now(),
-                        }, false); // Pass false to prevent auto-scrolling
+                        }); // Auto-scroll is now automatically suppressed for system messages
                     }
                 });
                 buttonContainer.append(applyDiffButton);

--- a/code-pwa/service-worker.js
+++ b/code-pwa/service-worker.js
@@ -149,16 +149,14 @@ self.addEventListener("fetch", function (event) {
 
 	// Special handler for version request
 	if (url.pathname.endsWith("/version.json")) {
-		console.debug(url)
+		console.debug("[service] Intercepted /version.json request");
+		const responseBody = { appName: "code.jakbox.dev", version: APP_VERSION };
+		const jsonResponse = new Response(JSON.stringify(responseBody), {
+			headers: { "Content-Type": "application/json" },
+		});
+		event.respondWith(jsonResponse); // Provide the custom response
+		return; // Ensure no further processing for this request
 	}
-	// 	const responseBody = { appName: "code.jakbox.dev", version: APP_VERSION }
-	// 	const jsonResponse = new Response(JSON.stringify(responseBody), {
-	// 		headers: { "Content-Type": "application/json" },
-	// 	})
-	// 	event.respondWith(jsonResponse)
-	// 	return
-	// }
-
     // --- NEW: Do not cache calls to external APIs like Gemini ---
     if (NON_CACHEABLE_HOSTS.includes(url.hostname)) {
         console.debug("[service] Bypassing cache for external API:", url.href);


### PR DESCRIPTION
This PR improves usability and feedback throughout the AI chat interface.

I let the AI right the PR message (and asked for it sassy).... I think this is how PR's should always be written now

----

This PR is a full-frontal assault on janky UX. We're making things smoother, smarter, and a whole lot less annoying.

### What's New, Gorgeous?

- Ctrl+Enter to Send: Because we're professionals, not monsters. Enter now correctly makes a new line.
- No More Scroll-Whiplash: System messages are now polite little sticky notifications at the top. They show up, say their piece, fade out, and most importantly, don't hijack your scrollbar.
- Impatient? Just Click It: If you can't wait 4 seconds for the sticky notice to fade, just click it to banish it immediately. Power to the people.
- Middle-Click Everything: File chips can now be nuked with a middle-click, just like tabs. I also squashed that obnoxious bug where it would try to paste your clipboard content.
- Context is Queen: System messages now actually tell you which files you added or removed. Revolutionary, I know.

#### Sanity Checks:
- Stopped the AI from having a meltdown when you only use an @-tag with no prompt. It just adds the file and chills out now.
- Fixed the scroll position flying to the top after you dealt with the stale file notice. We're being surgical with DOM updates instead of just bulldozing the whole chat.
- The "stale file" notice is now a big, unmissable sticky footer. No excuses for not seeing it.