### PR TITLE
fix the obliteration of the session undo history when applying DIFFs …

### DIFF
--- a/code-pwa/js/ai-manager.mjs
+++ b/code-pwa/js/ai-manager.mjs
@@ -1377,13 +1377,16 @@ class AIManager {
                         console.error("Diff application failed:", { originalContentFromContext, rawDiff });
                     } else {
                     	
-                    	// 4. Update the live file content in the editor
-                        tabToUpdate.config.session.setValue(newFileContentFromDiff);
-                        
-                        // applyCodeDiffToAceSession(tabToUpdate.config.session, tabToUpdate.config.session.getValue(), newFileContentFromDiff);
+                        // 4. Update the live file content in the editor, preserving undo history.
+                        const session = tabToUpdate.config.session;
+                        const doc = session.getDocument();
+                        const lastRow = doc.getLength() - 1;
+                        const lastCol = doc.getLine(lastRow).length;
+                        const fullRange = new window.ace.Range(0, 0, lastRow, lastCol);
+                        session.replace(fullRange, newFileContentFromDiff);
                         
                         // IMPORTANT: DO NOT call session.markClean() here.
-                        // setValue marks it dirty, which is correct because it's not saved to disk yet.
+                        // replace() marks it dirty, which is correct because it's not saved to disk yet.
                         // The user should manually save after applying.
 
                         // Provide visual feedback


### PR DESCRIPTION
Preserve undo history when applying diffs

Stop using session.setValue() to apply diffs. It's the nuclear option and it mercilessly obliterates the entire undo stack, which is terrible UX.

Replace that sledgehammer with the more civilized session.replace(). This correctly updates the document while preserving the sacred developer right to Ctrl+Z. Users can now apply diffs without the existential dread of an irreversible change.
