### PR TITLE
filter out code changes (diffs) from history sent to the LLM to reduc…

### DIFF
--- a/code-pwa/js/ai-ollama.mjs
+++ b/code-pwa/js/ai-ollama.mjs
@@ -278,7 +278,10 @@ class Ollama extends AI {
                         content: `--- File: ${msg.filename} ---\n\`\`\`${msg.language}\n${msg.content}\n\`\`\``
                     };
                 }
-                return { role: msg.role, content: msg.content };
+                // Map our internal 'model' role to what Ollama expects ('assistant') for chat history.
+                // This little switcheroo keeps the rest of the app consistent while complying with the API.
+                const role = msg.role === 'model' ? 'assistant' : msg.role;
+                return { role: role, content: msg.content };
             });
 
             // Add system prompt to the request body if it exists


### PR DESCRIPTION
…e it's confusion when addressing code changes, update ollama history to refer to the model as 'assistant' per newer API specs