### PR TITLE
feat: Refine UI and code block theming; streamline diff output

### DIFF
--- a/code-pwa/css/ai-manager.css
+++ b/code-pwa/css/ai-manager.css
@@ -53,19 +53,18 @@
 
 /* Overall container for rendered diffs */
 .conversation-area .response-block .diff-output {
-    background-color: rgba(0,0,0,0.25); /* A neutral background, maybe slightly darker than main chat area */
+    background-color: var(--bg-code); /* A neutral background, maybe slightly darker than main chat area */
     padding: 8px;
     border-radius: var(--borderRadius);
-    /*font-family: var(--font-family-monospace);*/
     font-size: var(--font-size-sm);
     overflow-x: auto; /* Allow horizontal scrolling for wide diff lines */
     white-space: pre; /* Preserve whitespace for diff format */
     margin-top: 8px;
     margin-bottom: 8px;
-    border: 1px solid var(--theme-border-color);
+    border: 1px solid var(--border-primary);
     line-height: 1.4; /* Improve readability */
-    color: var(--theme-text-color); /* Default text color */
-    font-family: roboto mono;
+    color: var(--text-primary); /* Default text color */
+    font-family: var(--font-mono);
 }
 
 
@@ -87,9 +86,9 @@
 }
 
 .conversation-area .response-block .code-button {
-    background-color: var(--theme-block-background);
-    border: 1px solid var(--theme-border-color);
-    color: var(--theme-text-color);
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    color: var(--text-primary);
     padding: 4px 8px;
     border-radius: var(--borderRadius);
     font-size: var(--font-size-xs);
@@ -97,8 +96,8 @@
 }
 
 .conversation-area .response-block .code-button:hover {
-    background-color: var(--theme-accent-hover);
-    color: var(--theme-accent-color);
+    background-color: var(--bg-tertiary);
+    color: var(--theme);
 }
 /* Ensure the pre element is positioned relatively for absolute button positioning */
 .conversation-area .response-block pre {
@@ -109,7 +108,7 @@
 
 .prompt-container {
     padding: 0px 0;
-    background-color: var(--background-color);
+    background-color: transparent;
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -142,7 +141,7 @@
 .prompt-area:disabled {
     opacity: 0.7;
     cursor: not-allowed;
-    background-color: rgba(0, 0, 0, 0.15);
+    background-color: var(--bg-secondary);
 }
 
 
@@ -156,14 +155,14 @@
 
 .theme-button {
     background-color: var(--theme);
-    color: var(--light);
+    color: var(--text-inverted);
     border: 1px solid var(--theme);
     cursor: pointer;
 }
 
 .theme-button:hover {
-    background-color: var(--themeDark);
-    border-color: var(--themeDark);
+    background-color: var(--theme-dark);
+    border-color: var(--theme-dark);
 }
 
 .submit-button {
@@ -171,25 +170,25 @@
 }
 
 .clear-button, .summarize-button { 
-    align-self: flex-end;
-    background-color: var(--low);
-    color: var(--button-text-color);
-    border: 1px solid var(--border-color);
+    align-self: flex-end; /* The clear and summarize buttons should be aligned to the end of the flex container. */
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
     cursor: pointer;
 }
 
 .clear-button:hover, .summarize-button:hover {
-    background-color: var(--themeDark); 
-    border-color: var(--mid); 
+    background-color: var(--theme-dark);
+    border-color: var(--border-primary);
 }
 
 /* Spinner specifically for use inside buttons */
 .button-spinner {
     width: 16px; /* Smaller for button context */
     height: 16px;
-    border: 2px solid rgba(255, 255, 255, 0.5); /* Use a color that works on the button background */
+    border: 2px solid color-mix(in srgb, var(--text-inverted) 50%, transparent); /* Use a color that works on the button background */
     border-radius: 50%;
-    border-top-color: var(--light); /* Spinner color */
+    border-top-color: var(--text-inverted); /* Spinner color */
     animation: spin 1s linear infinite;
     /* This will help center it as our Button class uses flexbox */
     margin: auto;
@@ -201,7 +200,7 @@
 
 .response-block {
     margin-bottom: 16px;
-    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.125), rgba(0, 0, 0, 0));
+    background: linear-gradient(to bottom, color-mix(in srgb, var(--text-primary) 10%, transparent), transparent);
     border-radius: 16px;
     padding: 0px 16px;
     /*border: 2px solid rgba(0,0,0,0.125);*/
@@ -247,8 +246,8 @@
 }
 
 .code-button {
-    background-color: rgba(120, 120, 120, 0.5);
-    color: white;
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
     border: none;
     border-radius: 50%;
     padding: 0px 4px;
@@ -261,19 +260,19 @@
 }
 
 .code-button:hover {
-    background-color: rgba(120, 120, 120, 0.7);
+    filter: brightness(0.9);
 }
 
 /* Styles for successful diff application */
 .code-button.diff-apply-success {
-    background-color: var(--green-soft)!important;
-    border-color: var(--green);
+    background-color: var(--diff-green-soft)!important;
+    border-color: var(--diff-green);
 }
 
 /* Styles for failed diff application */
 .code-button.diff-apply-failed {
-    background-color: var(--red-soft)!important; 
-    border-color: var(--red);
+    background-color: var(--diff-red-soft)!important;
+    border-color: var(--diff-red);
 }
 
 .prompt-pill-wrapper {
@@ -285,16 +284,16 @@
 }
 
 .prompt-pill {
-    background-color: var(--themeDark);
-    color: var(--ui-pri-bg); 
+    background-color: var(--theme-dark);
+    color: var(--text-inverted);
     padding: 0px 12px; 
     border-radius: 16px;
     word-wrap: break-word;
 }
 
 .delete-history-button {
-    background-color: var(--themeDark);
-    color: var(--light);
+    background-color: var(--theme-dark);
+    color: var(--text-inverted);
     border: none;
     border-radius: 50%; 
     width: 24px;
@@ -311,7 +310,7 @@
     right: -4px;
     opacity: 0; 
     transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.5); 
+    box-shadow: 0 1px 3px var(--shadow-color);
     z-index: 1;
 }
 
@@ -319,11 +318,11 @@
 .prompt-area .ace_editor.ace_read-only {
     opacity: 0.7;
     cursor: not-allowed;
-    background-color: rgba(0, 0, 0, 0.15);
+    background-color: var(--bg-secondary);
 }
 
 .delete-history-button:hover {
-    background-color: #dc3545; 
+    background-color: var(--color-error);
 }
 
 .prompt-pill-wrapper:hover .delete-history-button,
@@ -334,12 +333,12 @@
 .settings-panel {
     flex: 1;
     padding: 16px;
-    background-color: var(--themeDark);
-    color: var(--theme-text-color);
+    background-color: var(--theme-dark);
+    color: var(--text-inverted);
     display: none;
     flex-direction: column;
     overflow-y: auto;
-    background: linear-gradient(90deg, var(--theme) 31%, var(--themeDark) 31%);
+    background: linear-gradient(90deg, var(--theme) 31%, var(--theme-dark) 31%);
 }
 
 .settings-panel.active {
@@ -367,10 +366,10 @@
 .settings-panel select {
     flex-grow: 1;
     padding: 8px;
-    border: 1px solid var(--mid);
+    border: 1px solid var(--border-primary);
     border-radius: var(--buttonBorder);
-    background-color: var(--high);
-    color: var(--text-color);
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
     box-sizing: border-box;
     width: auto;
 }
@@ -431,8 +430,8 @@
 .loading-spinner {
     width: 32px;
     height: 32px;
-    border: 4px solid var(--low);
-    border-top-color: var(--theme);
+    border: 4px solid var(--border-secondary);
+    border-top-color: var(--theme); /* The top border of the loading spinner should be the theme color. */
     border-radius: 50%;
     animation: spin-simple 1s linear infinite;
 }
@@ -451,15 +450,15 @@
 }
 
 .progress-bar-inner.threshold-yellow {
-    background-color: #ffd700; 
+    background-color: var(--color-warning);
 }
 
 .progress-bar-inner.threshold-orange {
-    background-color: #ffa500; 
+    background-color: var(--color-warning-dark);
 }
 
 .progress-bar-inner.threshold-red {
-    background-color: #dc3545; 
+    background-color: var(--color-error);
 }
 
 
@@ -480,10 +479,10 @@
 }
 
 .context-file-pill {
-    background-color: var(--dark);
+    background-color: var(--bg-secondary);
     border: 1px solid var(--theme);
     color: var(--theme);
-    padding: 0px 12px;
+    padding: 0px 12px; /* A pill for a context file should have 0px top and bottom padding, and 12px left and right padding. */
     border-radius: 16px;
     flex-grow: 1;
     flex-shrink: 1;
@@ -491,12 +490,12 @@
 
 .file-size {
     font-size: 0.8em;
-    color: var(--text-color-secondary);
+    color: var(--text-secondary);
 }
 
 .system-message-block {
     margin-bottom: 8px;
-    padding: 8px 16px;
+    padding: 8px 16px; /* A system message block should have 8px top and bottom padding, and 16px left and right padding. */
     background: rgba(var(--text-color-rgb), 0.05);
     border-radius: var(--borderRadius);
     color: var(--text-color-secondary);
@@ -523,7 +522,7 @@ button:disabled,
 
 .ai-info-display {
     font-size: 0.85em;
-    color: var(--text-color-secondary);
+    color: var(--text-secondary);
     align-self: center; 
     padding-left: 8px;
     white-space: nowrap; 
@@ -543,18 +542,18 @@ button:disabled,
 .ai-filebar-container {
 	position: sticky; /* Now it's sticky within the conversation-area */
 	top: 0;
-	background-color: var(--background-color);
+	background-color: var(--bg-primary);
 	z-index: 2;
-	border-bottom: 1px solid var(--themeDark);
+	border-bottom: 1px solid var(--theme-dark);
 	display: flex;
 	flex-direction: column;
 }
 
 .ai-filebar-container > .progress-bar {
-	width: calc(100% - 16px); /* Match padding of file-context-bar */
+	width: calc(100% - 16px); /* Match padding of file-context-bar, which is 8px on each side. */
 	margin: 0 8px 6px 8px; /* Give it some space */
 	height: 6px;
-	background-color: var(--themeDark);
+	background-color: var(--theme-dark);
 	border-radius: 4px;
 }
 
@@ -573,10 +572,10 @@ button:disabled,
 .ai-session-tab-container {
     display: flex;
     align-items: flex-end; 
-    background-color: var(--background-color);
+    background-color: var(--bg-primary);
     padding: 0px 4px 0 4px; 
     gap: 4px;
-    border-top: 3px solid var(--themeDark); /* Swapped from border-bottom */
+    border-top: 3px solid var(--theme-dark); /* Swapped from border-bottom */
     flex-shrink: 0;
 }
 
@@ -593,7 +592,7 @@ button:disabled,
 }
 
 .ai-session-tab-container .new-session-button:hover {
-    background-color: rgba(0,0,0,0.25);
+    background-color: var(--bg-tertiary);
 }
 
 /* ... (rest of CSS) ... */
@@ -611,11 +610,11 @@ button:disabled,
 	position: absolute;
 	bottom: 0; /* Stick to the top of the conversation-area, below the file bar */
 	z-index: 3; /* Ensure it's above other chat content */
-	border: 1px solid var(--theme);
-	background: var(--themeDark);
-	color: var(--light);
+	border: 1px solid var(--theme); /* The border should be the theme color. */
+	background: var(--theme-dark);
+	color: var(--text-inverted);
 	animation: sticky-fade-out 5s linear forwards;
-	box-shadow: 0 5px 5px rgba(0, 0, 0, 0.15); /* Add a subtle shadow to lift it off the content */
+	box-shadow: 0 5px 5px var(--shadow-color); /* Add a subtle shadow to lift it off the content */
 	padding:0px;
 
 	padding: 0px;
@@ -627,8 +626,8 @@ button:disabled,
 /*    position: sticky;*/
 /*    bottom: 130px;*/
 /*    border: 1px solid var(--theme);*/
-/*    background: var(--themeDark);*/
-/*    color: var(--light);*/
+/*    background: var(--theme-dark);*/
+/*    color: var(--text-inverted);*/
     /* animation: sticky-fade-out 10s linear forwards; */
 /*    box-shadow: 0 5px 5px rgba(0, 0, 0, 0.15);*/
 /*}*/
@@ -646,8 +645,8 @@ button:disabled,
     position: sticky;
     bottom: 0;
     z-index: 4; /* Above other messages */
-    background-color: var(--dark); /* Solid background to obscure content behind it */
-    box-shadow: 0 -5px 10px rgba(0,0,0,0.2); /* Shadow on top to lift it from the content */
+    background-color: var(--bg-primary); /* Solid background to obscure content behind it */
+    box-shadow: 0 -5px 10px var(--shadow-color); /* Shadow on top to lift it from the content */
     padding: 8px 16px; /* Ensure consistent padding */
 }
 
@@ -664,15 +663,82 @@ button:disabled,
 .context-stale-notice button {
     padding: 6px 12px;
     border-radius: var(--borderRadius);
-    cursor: pointer;
-    border: 1px solid var(--border-color);
-    background-color: var(--low);
-    color: var(--button-text-color);
+    cursor: pointer; /* The cursor should be a pointer when hovering over a button. */
+    border: 1px solid var(--border-primary);
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
     font-size: 0.9em;
 }
 .context-stale-notice .update-button {
-    background-color: var(--theme);
-    border-color: var(--theme);
-    color: var(--light);
+    background-color: var(--theme); /* The background color for the update button should be the theme color. */
+    border-color: var(--theme); /* The border color for the update button should be the theme color. */
+    color: var(--text-inverted);
+}
+.context-stale-notice button:hover { filter: brightness(1.2); }
+
+/* Overrides for highlight.js to match the current ACE editor theme */
+.conversation-area .response-block pre .hljs-comment,
+.conversation-area .response-block pre .hljs-quote {
+    color: var(--hljs-comment, #7F848E); /* Default from atom-one-dark */
+}
+
+.conversation-area .response-block pre .hljs-built_in,
+.conversation-area .response-block pre .hljs-keyword,
+.conversation-area .response-block pre .hljs-selector-tag,
+.conversation-area .response-block pre .hljs-subst {
+    color: var(--hljs-keyword, #C678DD);
+}
+
+.conversation-area .response-block pre .hljs-number,
+.conversation-area .response-block pre .hljs-literal,
+.conversation-area .response-block pre .hljs-template-variable,
+.conversation-area .response-block pre .hljs-tag {
+    color: var(--hljs-number, #D19A66);
+}
+
+
+.conversation-area .response-block pre .hljs-string,
+.conversation-area .response-block pre .hljs-doctag {
+    color: var(--hljs-string, #98C379);
+}
+
+.conversation-area .response-block pre .hljs-title,
+.conversation-area .response-block pre .hljs-section,
+.conversation-area .response-block pre .hljs-selector-id,
+.conversation-area .response-block pre .hljs-title.class_, 
+.conversation-area .response-block pre .hljs-class,
+.conversation-area .response-block pre .hljs-title {
+    color: var(--hljs-class, #E5C07B);
+}
+
+.conversation-area .response-block pre .hljs-selector-attr,
+.conversation-area .response-block pre .hljs-attribute {
+	color: var(--hljs-attribute, #0089cd)
+}
+
+.conversation-area .response-block pre .hljs-selector-pseudo,
+.conversation-area .response-block pre .hljs-selector-class,
+.conversation-area .response-block pre .hljs-attr {
+    color: var(--hljs-selector, #9aaff2);
+}
+	
+}
+
+.conversation-area .response-block pre .hljs-title.function_ {
+    color: var(--hljs-function, #61AFEF);
+}
+
+.conversation-area .response-block pre .hljs-variable {
+	color: var(--hljs-variable, #e06c75);
+}
+
+.conversation-area .response-block pre .hljs-meta,
+.conversation-area .response-block pre .hljs-tag {
+    color: var(--hljs-tag, #e06c75);
+}
+.context-stale-notice .update-button {
+    background-color: var(--theme); /* The background color for the update button should be the theme color. */
+    border-color: var(--theme); /* The border color for the update button should be the theme color. */
+    color: var(--text-inverted);
 }
 .context-stale-notice button:hover { filter: brightness(1.2); }

--- a/code-pwa/css/diff-output.css
+++ b/code-pwa/css/diff-output.css
@@ -3,7 +3,6 @@
     color: var(--theme-text-color-light); /* Lighter text for metadata */
     background-color: var(--theme-block-background); /* Distinct background for header */
     border-bottom: 1px dashed var(--theme-border-color);
-    font-weight: bold;
 }
 
 /* Individual line divs inside .diff-output */
@@ -13,14 +12,12 @@
 
 /* Added lines */
 .diff-output .add {
-	font-weight:bold;
     color: var(--green); /* Bright green for additions */
     background-color: rgba(0, 128, 0, 0.2); /* Darken for better contrast */
 }
 
 /* Removed lines */
 .diff-output .remove {
-	font-weight:bold;
     color: var(--red); /* Bright red for removals */
     background-color: rgba(128, 0, 0, 0.2); /* Darken for better contrast */
 }

--- a/code-pwa/css/elements.css
+++ b/code-pwa/css/elements.css
@@ -1,20 +1,3 @@
-:root {
-	--ui-pri-bg: #fff;
-	--ui-pri-fg: #444;
-	--ui-sec-bg: #ccc;
-	--ui-sec-fg: #444;
-	--ui-effect: rgba(0, 0, 0, 0.25);
-	--ui-shadow: rgba(0, 0, 0, 0.125);
-	--ui-highlight-bg: #fff;
-	--ui-highlight-fg: #444;
-	--ui-icon-color: inherit;
-	--ui-icon-highlight: inherit;
-	--ui-bg: #fff;
-	--menuHeight: 48px;
-	--buttonBarHeight: 64px;
-}
-
-
 ui-element {
 	display: inline-block;
 }
@@ -45,7 +28,7 @@ ui-view {
 	bottom: 0px;
 	max-height: 100vh;
 	overflow: auto;
-	background: var(--ui-bg);
+	background: var(--bg-primary);
 }
 
 ui-view.full {
@@ -66,8 +49,8 @@ ui-content-fill {
 ui-actionbar {
 	position: sticky;
 	display: block;
-	background: var(--ui-pri-bg);
-	color: var(--ui-pri-fg);
+	background: var(--bg-primary);
+	color: var(--text-primary);
 	z-index: 1;
 	width: 100%;
 	left: 0px;
@@ -84,11 +67,11 @@ ui-actionbar > * {
 }
 ui-actionbar[hook="top"] {
 	top: 0px;
-	box-shadow: 0 5px 5px var(--ui-shadow);
+	box-shadow: 0 5px 5px var(--shadow-color);
 }
 ui-actionbar[hook="bottom"] {
 	bottom: 0px;
-	box-shadow: 0 -3px 5px var(--ui-shadow);
+	box-shadow: 0 -3px 5px var(--shadow-color);
 }
 
 ui-actionbar[slim] {
@@ -131,9 +114,9 @@ ui-button-counter [type="counter"] {
 	font-size: 0.8em;
 	text-align: center;
 
-	border-radius: 100%;
-	color: var(--ui-highlight-fg);
-	background: var(--ui-highlight-bg);
+	border-radius: 100%; /* A counter should be circular. */
+	color: var(--text-primary);
+	background: var(--bg-primary);
 }
 ui-button-counter:empty {
 	opacity: 0;
@@ -145,7 +128,7 @@ ui-button-counter ui-icon {
 	height: 1.5em;
 	line-height: 1.5em;
 	max-width: 1.5em;
-	color: var(--ui-icon-color);
+	color: var(--icon-color);
 }
 
 [slim] > ui-button ui-icon,
@@ -175,7 +158,7 @@ ui-file-item {
 [slim] > ui-file-item ui-icon {
 	height: 26px;
 	line-height: 25px;
-	color: var(--ui-icon-color);
+	color: var(--icon-color);
 }
 [slim] ui-file-item {
 	min-height: 26px;
@@ -200,7 +183,7 @@ effect-ripple {
 	width: 10px;
 	height: 10px;
 	z-index: 2;
-	background: var(--ui-effect);
+	background: var(--shadow-color);
 	border-radius: 100%;
 }
 
@@ -213,17 +196,17 @@ effect-ripple[active] {
 }
 
 ui-button:focus {
-	background: rgba(0, 0, 0, 0.125);
+	background: var(--bg-tertiary);
 }
 
 ui-actionbar ui-panel {
 	display: block;
 	position: absolute;
-	background: var(--ui-sec-bg);
-	color: var(--ui-sec-fg);
+	background: var(--bg-secondary);
+	color: var(--text-primary);
 	right: 8px;
 	width: 280px;
-	box-shadow: 0 5px 5px var(--ui-shadow);
+	box-shadow: 0 5px 5px var(--shadow-color);
 	max-width: 90%;
 	top: 100%;
 	z-index: 2;
@@ -245,7 +228,7 @@ ui-actionbar[open] ui-panel {
 ui-actionbar[hook="bottom"] ui-panel {
 	top: auto;
 	bottom: 100%;
-	box-shadow: 0 -5px 5px var(--ui-shadow);
+	box-shadow: 0 -5px 5px var(--shadow-color);
 }
 
 ui-actionbar ui-panel > ui-inline,
@@ -257,11 +240,11 @@ ui-actionbar ui-panel > ui-button-counter {
 }
 
 ui-actionbar ui-panel ui-button:hover {
-	background: var(--ui-highlight-bg);
-	color: var(--ui-highlight-fg);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
 }
 ui-actionbar ui-panel ui-button:hover ui-icon {
-	color: var(--ui-icon-highlight);
+	color: var(--icon-color);
 }
 
 ui-view ui-button,
@@ -308,13 +291,13 @@ ui-tabbar[slim] > ui-button ui-icon {
 
 ui-button[active],
 ui-button-counter[active] {
-	background: var(--ui-highlight-bg);
-	color: var(--ui-highlight-fg);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
 }
 
 ui-button[disabled] {
 	opacity: 0.33;
-	background: var(--ui-highlight-bg);
+	background: var(--bg-tertiary);
 	cursor: not-allowed;
 	filter: brightness(0.9);
 }
@@ -330,8 +313,8 @@ ui-actionbar > ui-inline {
 ui-icon-tabbar {
 	display: flex;
 	flex-direction: column;
-	background: var(--themeDark);
-	color: var(--ui-sec-fg);
+	background: var(--theme-dark);
+	color: var(--text-primary);
 	padding: 8px 0 0 4px;
 	border-right: 2px solid var(--theme);
 }
@@ -343,18 +326,18 @@ ui-icon-tab {
 	height: 48px;
 	width: 48px;
 	cursor: pointer;
-	color: var(--ui-icon-color);
+	color: var(--icon-color);
 	border-radius: 8px 0 0 8px;
 }
 
 ui-icon-tab[active] {
 	background: var(--theme);
-	color: var(--ui-highlight-bg);
+	color: var(--text-inverted);
 }
 
 ui-icon-tab:hover {
-	background: var(--ui-sec-fg);
-	color: var(--ui-sec-bg);
+	background: var(--text-primary);
+	color: var(--bg-secondary);
 }
 
 ui-icon-tab ui-icon {
@@ -381,8 +364,8 @@ ui-tabbar[slim] > ui-tab-item {
 	position: relative;
 	min-height: 30px;
 	line-height: 32px;
-	background: var(--ui-sec-bg);
-	color: var(--ui-highlight-fg);
+	background: var(--bg-secondary);
+	color: var(--text-primary);
 	margin-top: 6px;
 	padding-right: 3px; /* Add some space on the right for the close icon */
 	padding-left: 3px; /* Adjust padding for new status icon */
@@ -403,7 +386,7 @@ ui-tabbar[slim] > ui-tab-item .status-icon {
 ui-tabbar[slim] > ui-tab-item[is-changed] .status-icon {
 	opacity: 1; /* Full opacity for 'circle' icon */
 	font-size:1em;
-	color: var(--light);
+	color: var(--text-inverted);
 }
 
 ui-tabbar[slim] > ui-tab-item ui-inline {
@@ -415,7 +398,7 @@ ui-tabbar[slim] > ui-tab-item ui-inline {
 	flex-grow: 1; /* Allow text to expand and fill space */
 }
 ui-tabbar[slim] > ui-tab-item[active] {
-	background: var(--ui-highlight-bg);
+	background: var(--bg-primary);
 }
 ui-tabbar[slim] > ui-tab-item .status-icon,
 ui-tabbar[slim] > ui-tab-item ui-icon[close] {
@@ -455,12 +438,12 @@ ui-tabbar[slim] > ui-tab-item[active]:hover .status-icon {
 ui-tabbar[slim] > ui-tab-item:hover ui-icon[close] {
 	display:inline-block;
 	position:absolute;
-	background: rgba(0,0,0,0.25);
+	background: var(--shadow-color);
 	border-radius: 16px;
-	color:var(--light);
+	color:var(--text-inverted);
 }
 ui-tabbar[slim] > ui-tab-item:hover ui-icon[close]:hover {
-	background: var(--red-soft);
+	background: var(--diff-red-soft);
 }
 
 ui-tabbar[slim] > ui-tab-item ui-icon[close]:hover {
@@ -526,7 +509,7 @@ ui-tabbar > [hook="right"] {
 ui-file-list {
 	position: relative;
 	display: block;
-	background: #eeeeee;
+	background: var(--bg-secondary);
 	z-index: 0;
 	height: calc(100vh - 108px);
 	padding: 0px;
@@ -543,16 +526,16 @@ ui-file-list > .inner {
 
 ui-file-list > .inner.hover {
 	/*background:#0af;*/
-	border: 3px dashed #0af;
+	border: 3px dashed var(--theme);
 	border-radius: 16px;
 }
 
 ui-file-list > .inner > a {
 	/*background: center center no-repeat;*/
 	display: inline-block;
-	position: relative;
-	background: #fff;
-	margin: 4px;
+	position: relative; /* This is required for the child label to be positioned correctly */
+	background: var(--bg-primary);
+	margin: 4px; /* Add some space around the file list items. */
 	width: calc(20% - 24px);
 	min-height: 100px;
 	border: 8px solid #fff;
@@ -565,10 +548,10 @@ ui-file-list > .inner > a {
 
 ui-file-list > .inner > * > label {
 	position: absolute;
-	background: rgba(255, 255, 255, 0.75);
+	background: color-mix(in srgb, var(--bg-primary) 75%, transparent);
 	font-size: 12px;
 	height: 9px;
-	padding: 4px;
+	padding: 4px; /* A label should have 4px of padding on all sides. */
 	color: #333;
 	left: 0px;
 	right: 0px;
@@ -584,12 +567,12 @@ ui-file-list > .progress {
 	width: 5%;
 	max-height: 5px;
 	height: 0px;
-	background: #0af;
+	background: var(--theme);
 	transition: width 333ms ease-in-out, height 333ms ease-in-out;
 }
 
 ui-file-list > .inner > ui-file-item:not(:first-child) {
-	border-top: 1px solid var(--ui-shadow);
+	border-top: 1px solid var(--border-secondary);
 	padding-top: 4px;
 	margin-top: 4px;
 }
@@ -632,12 +615,12 @@ ui-file-item[open] > ui-inline {
 }
 
 ui-file-item:focus {
-	background: rgba(0, 0, 0, 0.125);
+	background: var(--bg-tertiary);
 }
 
 ui-file-item[active] {
-	background: rgba(0, 0, 0, 0.4);
-	color: var(--ui-sec-fg);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
 }
 
 ui-file-item[active] ui-icon {
@@ -695,9 +678,9 @@ ui-menu {
 	top: 0px;
 	transition: opacity 200ms ease-in-out;
 	z-index: 100;
-	background: var(--ui-pri-bg);
-	color: var(--ui-pri-fg);
-	box-shadow: 0 3px 12px rgba(0, 0, 0, 0.4);
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	box-shadow: 0 3px 12px var(--shadow-color);
 	border-radius: 0px 2px 4px 4px;
 	overflow-y: auto;
 }
@@ -707,7 +690,7 @@ ui-menu[left] {
 }
 ui-menu[up] {
 	border-radius: 4px 4px 0px 2px;
-	box-shadow: 0 -3px 12px rgba(0, 0, 0, 0.25);
+	box-shadow: 0 -3px 12px var(--shadow-color);
 }
 ui-menu[up][left] {
 	border-radius: 4px 4px 0px 2px;
@@ -740,8 +723,8 @@ ui-menu ui-menu-item ui-inline[hook="right"] {
 	margin-left: 25px;
 }
 ui-menu ui-menu-item:hover {
-	background: var(--ui-sec-bg);
-	color: var(--ui-sec-fg);
+	background: var(--bg-secondary);
+	color: var(--text-primary);
 }
 
 ui-menu ui-menu-item ui-icon {
@@ -752,7 +735,7 @@ ui-menu ui-menu-item ui-icon {
 	line-height: 40px;
 	font-size: 20px;
 	vertical-align: middle;
-	color: var(--ui-sec-bg);
+	color: var(--icon-color);
 }
 
 ui-menu[slim] ui-menu-item ui-icon {
@@ -761,7 +744,7 @@ ui-menu[slim] ui-menu-item ui-icon {
 }
 
 ui-menu ui-menu-item:hover ui-icon {
-	color: var(--ui-pri-fg);
+	color: var(--text-primary);
 	opacity: 0.5;
 }
 
@@ -775,7 +758,7 @@ ui-menu-item:last-child {
 ui-menu-split {
 	display: block;
 	height: 1px;
-	background: var(--ui-sec-bg);
+	background: var(--border-secondary);
 	width: 96%;
 	margin: 2px auto;
 }
@@ -793,11 +776,11 @@ ui-panel[type="modal"] {
 	left: 33%;
 	width: 33%;
 	height: 33%;
-	background: var(--ui-pri-bg);
+	background: var(--bg-primary);
 	box-sizing: border-box;
 	border-radius: 8px;
 	padding: 8px;
-	box-shadow: 0 0 16px rgba(0, 0, 0, 0.25);
+	box-shadow: 0 0 16px var(--shadow-color);
 	overflow-y: auto;
 }
 
@@ -830,8 +813,8 @@ ui-panel[type="modal"][blank] + ui-blank {
 	top: 0px;
 	left: 0px;
 	right: 0px;
-	bottom: 0px;
-	background: rgba(0, 0, 0, 0.125);
+	bottom: 0px; /* The bottom of the blank overlay should be 0px from the bottom of the viewport. */
+	background: var(--bg-overlay);
 }
 
 ui-panel[type="modal"][blank][active] + ui-blank {
@@ -850,12 +833,12 @@ ui-panel[type="modal"] h1 small {
 
 @keyframes ripple {
 	0% {
-		background: var(--ui-effect);
+		background: var(--shadow-color);
 		transform: scale(0.01, 0.01);
 		opacity: 1;
 	}
 	99% {
-		background: var(--ui-effect);
+		background: var(--shadow-color);
 		transform: scale(40, 40);
 		opacity: 0;
 	}
@@ -883,13 +866,13 @@ ui-media-view {
 	bottom: 0;
 	z-index: 5;
 	background: linear-gradient(45deg, rgba(0,0,0,0.05) 25%, transparent 25%), linear-gradient(-45deg, rgba(0,0,0,0.1) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, rgba(0,0,0,0.05) 75%), linear-gradient(-45deg, transparent 75%, rgba(0,0,0,0.1) 75%);
-	background-size: 20px 20px;
-	background-color: var(--mid);
+	background-size: 20px 20px; /* The background pattern should be 20px by 20px. */
+	background-color: var(--bg-secondary);
 	display: none;
 }
 
 ui-media-view img {
-	box-shadow: 0px 0px 50px rgba(0,0,0,0.5);
+	box-shadow: 0px 0px 50px var(--shadow-color);
 }
 
 ui-sidebar-panel {
@@ -906,9 +889,9 @@ ui-sidebar-panel[active] {
 }
 
 ui-filechip {
-	background-color: var(--dark);
+	background-color: var(--bg-secondary);
 	border: 1px solid var(--theme);
-	color: var(--high);
+	color: var(--text-primary);
 	padding: 1px 4px 1px 8px;
 	border-radius: 16px;
 	font-size: 1em;
@@ -921,8 +904,8 @@ ui-filechip {
 }
 
 ui-filechip:hover {
-	background-color: var(--themeDark);
-	color: var(--light);
+	background-color: var(--theme-dark);
+	color: var(--text-inverted);
 }
 
 ui-filechip > ui-icon[close] { font-size: 1.1em; line-height: 1; }

--- a/code-pwa/css/main.css
+++ b/code-pwa/css/main.css
@@ -1,34 +1,77 @@
 :root {
-	/* theme colours are now specified in index.html */
-	/*--theme: #00aabb;*/
-	/*--themeDark: #007788;*/
-	--light: #fff;
-	--high: #dadada;
-	--mid: #afafaf;
-	--low: #455155;
-	--dark: #384144;
-	--text-color: #222a37;
-	--button-text-color: #dadada;
-	--animRate:10ms;
+	/*
+	  Hello there, fellow code-surfer! 🏄‍♂️
+	  I'm setting up a new, unified color system to make our app look fabulous
+	  in both light and dark modes. Say goodbye to rogue hex codes!
+	*/
+
+	/* Theme colors (assumed to be set via JS or in index.html) */
+	--theme: #00aabb;
+	--theme-dark: #007788;
+
+	/* Semantic Filetype Colors */
+	--color-file-js: #f0db4f;
+	--color-file-css: #2965f1;
+	--color-file-html: #e34c26;
+	--color-file-php: #777bb3;
+
+	/* State & Feedback Colors */
+	--color-success: #4caf50;
+	--color-error: #f44336;
+	--color-warning: #ffc107;
+	--color-warning-dark: #ffa000;
+
+	/* Diff Highlight Colors */
+	--diff-green: rgb(128,164,128);
+	--diff-red: rgba(164,128,128);
+	--diff-green-soft: rgba(0,120,0,0.15);
+	--diff-red-soft: rgba(120,0,0,0.15);
+	--diff-grey: #777777;
+
+	/* Sizing & Spacing */
+	--animRate: 10ms;
 	--tabRadius: 4px 4px 0 0;
 	--tabHeight: 37px;
 	--menuHeight: 34px;
 	--statusHeight: 34px;
 	--editorTop: calc(var(--tabHeight));
-	--ui-icon-color: var(--mid);
-	
-	/* diff highlight colours */
-	--green: rgb(128,164,128);
-	--red: rgba(164,128,128);
-	--grey: #777777;
-
-	--green-soft: rgba(0,120,0,0.33);
-	--red-soft: rgba(120,0,0,0.33);
-
 	--buttonBorder: 8px;
 	--borderRadius: 8px;
-	
-	--theme-text-color: #fff;
+
+	/* Fonts */
+	--font-sans: system-ui, roboto, arial, sans;
+	--font-mono: 'roboto mono', monospace;
+
+	/* --- Light Mode Palette --- */
+	--bg-primary: #D6D8DA;
+	--bg-secondary: #C8CACD;
+	--bg-tertiary: #B8BABF;
+	--bg-overlay: rgba(0,0,0,0.5);
+	--bg-code: #E3E5EE;
+	--bg-terminal: #222222;
+
+	--text-primary: #3A3A3A;
+	--text-secondary: #5A5A5A;
+	--text-muted: #7A7A7A;
+	--text-inverted: #ffffff;
+
+	--border-primary: #A9ADB1;
+	--border-secondary: #B8BABF;
+	--icon-color: #3b3b3b;
+	--shadow-color: rgba(0,0,0,0.1);
+
+	/* Highlight.js Colors for Light Mode (Chrome-inspired) */
+	--hljs-bg: var(--bg-code);
+	--hljs-text: var(--text-primary);
+	--hljs-comment: #236e24;
+	--hljs-keyword: #930F80;
+	--hljs-selector: #008393;
+	--hljs-attribute, #0089cd;
+	--hljs-number: #0000CD;
+	--hljs-string: #1A1AA6;
+	--hljs-function: #0000A2;
+	--hljs-variable: #318495;
+	--hljs-class: var(--hljs-text);
 }
 
 a,
@@ -49,10 +92,10 @@ tr.ace_optionsMenuEntry { line-height:1.5em; font-size:14px; }
 button { border:0; }
 
 body {
-	font-family:system-ui, roboto, arial, sans;
+	font-family: var(--font-sans);
 	font-size:13px;
     overflow: hidden;
-	background:var(--light);
+	background:var(--bg-primary);
 	margin:0; padding:0;
 }
 
@@ -75,8 +118,8 @@ body {
 ui-tabbar[slim] > ui-tab-item {
 	background: none;
 	color: inherit;
-	border-style: solid;
-	border-color: var(--themeDark);
+	border-style: solid; /* a tab's border color should be the theme-dark color */
+	border-color: var(--bg-tertiary);
 	border-width: 0 1px;
 	margin-left: -1px;
 	transition: background 150ms ease-in-out, margin 100ms ease-in-out;
@@ -86,20 +129,20 @@ ui-tabbar[slim] > ui-tab-item:first-of-type {
 	margin-left: 0;
 }
 ui-tabbar[slim] > ui-tab-item[active] {
-	background: var(--themeDark);
-	color: var(--light);
+	background: var(--theme-dark);
+	color: var(--text-inverted);
 	position: relative;
 	z-index: 1;
 }
 .current ui-tabbar[slim] > ui-tab-item[active] {
 	border-radius: 4px 4px 0 0;
 	background: var(--theme);
-	border-color: var(--theme);
+	border-color: var(--theme); /* The border color for the current tab should be the theme color */
 }
 
 /*ui-tabbar[slim]>ui-tab-item:hover+ui-tab-item { background: var(--dark);  }*/
 ui-tabbar[slim]>ui-tab-item:not([active]):hover {
-	background: var(--high);
+	background: var(--bg-tertiary);
 }
 ui-tabbar[slim]>ui-tab-item[active]:hover {
 	filter:brightness(1.1);
@@ -121,8 +164,8 @@ ui-tab-item.drop-highlight {
     bottom: calc( var(--statusHeight)  +  2px );
     left: 0;
     right: 0;
-    box-shadow: 0 0 10px rgba(0,0,0,0.5);
-    background: var(--dark);
+    box-shadow: 0 0 10px var(--shadow-color);
+    background: var(--bg-code);
 
     user-select:none;
     -webkit-user-select:none;
@@ -136,7 +179,7 @@ ui-tab-item.drop-highlight {
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0,0,0,0.5);
+    background: var(--bg-overlay);
     z-index: 10;
     visibility: hidden;
 }
@@ -154,8 +197,8 @@ ui-tab-item.drop-highlight {
     top: 0px;
     bottom: 0px;
     line-height:1.3em;
-    box-shadow: 0 0 10px rgba(0,0,0,0.5);
-    background:rgba(0,0,0,0.25);
+    box-shadow: 0 0 10px var(--shadow-color);
+    background:rgba(0,0,0,0.2);
     
     user-select:none;
     -webkit-user-select:none;
@@ -210,18 +253,18 @@ ui-menu::-webkit-scrollbar,
 .ace_scrollbar-v::-webkit-scrollbar-track,
 ui-file-list .inner::-webkit-scrollbar-track,
 ui-menu::-webkit-scrollbar-track,
-#ace_settingsmenu::-webkit-scrollbar-track,
+.darkmode #ace_settingsmenu::-webkit-scrollbar-track,
 .xterm-viewport::-webkit-scrollbar-track {
 	width: .66em; height: .66em;
-	box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+	box-shadow: inset 0 0 6px var(--shadow-color);
 }
 
 .ace_scrollbar::-webkit-scrollbar-thumb,
 ui-file-list .inner::-webkit-scrollbar-thumb,
 ui-menu::-webkit-scrollbar-thumb,
-#ace_settingsmenu::-webkit-scrollbar-thumb,
+.darkmode #ace_settingsmenu::-webkit-scrollbar-thumb,
 .xterm-viewport::-webkit-scrollbar-thumb {
-	background-color: darkgrey;
+	background-color: var(--text-muted);
 	border-radius:4px;
 }
 
@@ -259,8 +302,8 @@ header button {
 	background: var(--theme);
 	height:30px;
 	margin:3px 0;
-	pointer-events:none;
-	border-right:1px solid rgba(0,0,0,0.75);
+	pointer-events:none; /* The 'close' button in the header should not be interactive. */
+	border-right:1px solid var(--shadow-color);
 	margin-right:5px;
 }
 
@@ -272,7 +315,7 @@ header button img {
 
 header nav {
 	/*font-family:roboto, arial, sans;*/
-	color:var(--light); }
+	color:var(--text-inverted); }
 
 ui-actionbar#menu {
 	min-height: env(titlebar-area-height, 32px);
@@ -284,8 +327,8 @@ ui-actionbar#menu {
 }
 
 ui-actionbar#menu>ui-inline:first-of-type {
-	color:#000;
-	border-right: 1px solid rgba(0,0,0,0.5);
+	color:var(--text-inverted);
+	border-right: 1px solid var(--shadow-color);
 	padding-right:8px;
 }
 
@@ -300,14 +343,14 @@ ui-actionbar[slim]#fileActions {
 }
 
 ui-actionbar#menu ui-button {
-	color:#fff;
+	color:var(--text-inverted);
 	-webkit-app-region: no-drag;
 	app-region: no-drag;
 
 }
 
 ui-actionbar#menu ui-panel ui-button {
-	color:#444
+	color:var(--text-primary);
 }
 
 ui-button ui-icon {
@@ -325,8 +368,8 @@ ui-button:hover {
 
 ui-button.themed {
     border-radius: 8px;
-    background: var(--low);
-    color: var(--button-text-color);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
 }
 ui-button.themed ui-icon {
     color: inherit;
@@ -334,11 +377,8 @@ ui-button.themed ui-icon {
 
 ui-button.cancel {
 	border-radius: 8px;
-    color: var(--mid);
-    background: var(--dark);
-}
-ui-button.cancel ui-icon {
-    color: inherit
+    color: var(--text-secondary);
+    background: var(--bg-tertiary);
 }
 
 
@@ -369,43 +409,43 @@ ui-panel.slideDown[active] {
 }
 
 ui-menu[slim] ui-menu-item[icon="done"]:not(:hover) {
-	color: var(--light);
+	color: var(--text-inverted);
 	background:var(--theme);
 }
 ui-menu[slim] ui-menu-item[icon="done"]:not(:hover) ui-icon {
-	color: var(--light);
+	color: var(--text-inverted);
 }
 
 [slim] ui-menu-item[icon="done"]:not(:hover) {
-	color: var(--light);
+	color: var(--text-inverted);
 	background:var(--theme);
 }
 ui-menu[slim] ui-menu-item[icon="done"]:not(:hover) ui-icon {
-	color: var(--light);
+	color: var(--text-inverted);
 }
 
 ui-file-item[active] {
 	background: var(--theme);
-	color: var(--light);
+	color: var(--text-inverted);
 }
 
-ui-file-item[icon=javascript] ui-icon:first-child { color:#cd0; }
-ui-file-item[icon=css] ui-icon:first-child { color:#0ca; }
-ui-file-item[icon=html] ui-icon:first-child { color:#d77; }
-ui-file-item[icon=php] ui-icon:first-child { color:#b0b; }
-ui-file-item[icon=data_object] ui-icon:first-child { color: var(--light); opacity: 0.75; }
-ui-file-item[icon=image_not_supported] ui-icon:first-child { color: var(--light); opacity: 0.33; }
+ui-file-item[icon=javascript] ui-icon:first-child { color: var(--color-file-js); }
+ui-file-item[icon=css] ui-icon:first-child { color: var(--color-file-css); }
+ui-file-item[icon=html] ui-icon:first-child { color: var(--color-file-html); }
+ui-file-item[icon=php] ui-icon:first-child { color: var(--color-file-php); }
+ui-file-item[icon=data_object] ui-icon:first-child { color: var(--icon-color); opacity: 0.75; }
+ui-file-item[icon=image_not_supported] ui-icon:first-child { color: var(--icon-color); opacity: 0.33; }
 
-ui-file-item[active] ui-icon:first-child { color: var(--light); }
+ui-file-item[active] ui-icon:first-child { color: var(--text-inverted); }
 
 /* Tab icon colors for inactive tabs, mirroring file list */
-ui-tab-item[data-status-icon-type=javascript]:not([active]) .status-icon { color:#cd0; }
-ui-tab-item[data-status-icon-type=css]:not([active]) .status-icon { color:#0ca; }
-ui-tab-item[data-status-icon-type=html]:not([active]) .status-icon { color:#d77; }
-ui-tab-item[data-status-icon-type=php]:not([active]) .status-icon { color:#b0b; }
-ui-tab-item[data-status-icon-type=data_object]:not([active]) .status-icon { color: var(--mid); }
-ui-tab-item[data-status-icon-type=code]:not([active]) .status-icon { color: var(--mid); }
-ui-tab-item[data-status-icon-type=image]:not([active]) .status-icon { color: var(--mid); }
+ui-tab-item[data-status-icon-type=javascript]:not([active]) .status-icon { color: var(--color-file-js); }
+ui-tab-item[data-status-icon-type=css]:not([active]) .status-icon { color: var(--color-file-css); }
+ui-tab-item[data-status-icon-type=html]:not([active]) .status-icon { color: var(--color-file-html); }
+ui-tab-item[data-status-icon-type=php]:not([active]) .status-icon { color: var(--color-file-php); }
+ui-tab-item[data-status-icon-type=data_object]:not([active]) .status-icon { color: var(--icon-color); }
+ui-tab-item[data-status-icon-type=code]:not([active]) .status-icon { color: var(--icon-color); }
+ui-tab-item[data-status-icon-type=image]:not([active]) .status-icon { color: var(--icon-color); }
 
 /* Hide status icons in AI and Terminal session tabs for a cleaner look */
 .ai-session-tabs ui-tab-item .status-icon,
@@ -424,11 +464,11 @@ ui-tab-item[data-status-icon-type=image]:not([active]) .status-icon { color: var
 	top:0;
 	left:0;
 	right:0;
-	background: var(--light);
+	background: var(--bg-primary);
 	display:flex;
 	overflow-x: auto;
     box-sizing: border-box;
-    border-bottom:2px solid var(--themeDark);
+    border-bottom:2px solid var(--theme-dark);
     padding-right:40px;
 }
 
@@ -439,7 +479,7 @@ ui-tabbar.show-split-view-indicator::after {
     top: 0;
     bottom: 0;
     width: 100px; /* This is the 100px region */
-    background: rgba(0, 255, 0, 0.1); /* Light green overlay */
+    background: var(--diff-green-soft); /* Light green overlay */
     pointer-events: none; /* Ensure it doesn't interfere with drag events */
     display: block;
 }
@@ -457,13 +497,13 @@ body.showSplitView #leftTabs {
 #sidebar {
 	z-index:5;
 	opacity:0;
-	background:var(--light);
+	background:var(--bg-primary);
 	position:absolute;
 	width:256;
 	left:-256;
 	top:var(--menuHeight) !important;
 	bottom: var(--statusHeight);
-	overflow:hidden;
+	overflow:visible;
 	pointer-events:none;
 }
 
@@ -505,7 +545,7 @@ body.showSplitView #leftTabs {
 	z-index:5;
 	top: var(--menuHeight);
 	right:0px;
-	background: var(--light);
+	background: var(--bg-primary);
 }
 
 #drawer {
@@ -514,40 +554,53 @@ body.showSplitView #leftTabs {
     -webkit-user-select:none;
 }
 
+.darkmode {
+	/* --- Dark Mode Palette --- */
+	--bg-primary: #384144;
+	--bg-secondary: #455155;
+	--bg-tertiary: #2a3235;
+	--bg-overlay: rgba(0,0,0,0.5);
+	--bg-code: rgba(0,0,0,0.25);
+	--text-primary: #dadada;
+	--text-secondary: #afafaf;
+	--text-muted: #777777;
+	/* Inverted text is for use on theme-colored backgrounds */
+	--text-inverted: #ffffff;
+	--border-primary: #555555;
+	--border-secondary: #444444;
+	--icon-color: #3b3b3b;
+	--shadow-color: rgba(0,0,0,0.25);
+
+	/* Highlight.js Colors for Dark Mode (Code-inspired) */
+	--hljs-bg: var(--bg-code);
+	--hljs-text: var(--text-primary);
+	--hljs-comment: #666666;
+	--hljs-keyword: #F92672;
+	--hljs-selector: #87df00;
+	--hljs-attribute, #85e4f5;
+	--hljs-number: #AE81FF;
+	--hljs-string: #ccffbb;
+	--hljs-function: #A6E22E;
+	--hljs-variable: #A6E22E;
+	--hljs-class: var(--hljs-text);
+}
+
 .darkmode,
-.darkmode ui-menu,
-.darkmode #leftTabs,
-.darkmode #rightTabs,
-.darkmode #sidebar,
-.darkmode #statusbar,
-.darkmode #ace_settingsmenu,
-.darkmode #kbshortcutmenu,
-.darkmode #toggleSplitView,
-.darkmode ui-panel,
-.darkmode ui-file-list,
+.darkmode body,
 .darkmode ui-actionbar {
-	background: var(--dark);
-	color: var(--mid);
-}
-
-.darkmode #drawer {
-	background: var(--dark);
-	color: var(--mid);
-}
-
-.darkmode ui-actionbar {
-	color: var(--light); 
+	background-color: var(--bg-primary);
+	color: var(--text-primary);
 }
 
 .darkmode #ace_settingsmenu input,
 .darkmode #ace_settingsmenu select,
 .darkmode #ace_settingsmenu button {
-	background: var(--mid);
-	color: var(--dark);
+	background: var(--bg-secondary);
+	color: var(--text-primary);
 }
 
 .darkmode ui-tabbar[slim]>ui-tab-item:not([active]):hover {
-	background: var(--low);
+	background: var(--bg-tertiary);
 }
 
 
@@ -566,8 +619,8 @@ body.showSplitView #leftTabs {
 	top:4px;
 	margin-left:-200px;
 	border-radius:4px;
-	box-shadow: 0px 5px 10px rgba(0,0,0,0.25);
-	background:#fff;
+	box-shadow: 0px 5px 10px var(--shadow-color);
+	background:var(--bg-primary);
 	
 	transition: transform 200ms ease-in-out, opacity 200ms ease-in-out;
 	transform: scale(1,0);
@@ -583,8 +636,8 @@ body.showSplitView #leftTabs {
 	top:4px;
 	margin-left:-300px;
 	border-radius:4px !important;
-	box-shadow: 0px 5px 10px rgba(0,0,0,0.25);
-	background:#fff;
+	box-shadow: 0px 5px 10px var(--shadow-color);
+	background:var(--bg-primary);
 }
 
 
@@ -624,22 +677,20 @@ body.showSplitView #leftTabs {
 	position:fixed;
 	width:400px;
 	max-height:400px;
-	overflow:auto;
-	box-shadow: 0px 5px 10px rgba(0,0,0,0.25);
-	background:#fff;
+	overflow:auto; /* Allow scrolling for long lists */
+	box-shadow: 0px 5px 10px var(--shadow-color);
+	background:var(--bg-primary);
 	top: 100px;
 	z-index:10;
 	
 	border-radius:4px;
-	box-shadow: 0px 5px 10px rgba(0,0,0,0.25);
-	background:#fff;
 }
 #omni .results ui-block {
-	color: #444; /* Darker text for better contrast */
+	color: var(--text-primary); /* Darker text for better contrast */
 	padding: 8px 12px;
 	cursor: pointer;	
 	text-align:left;
-	border-bottom: 1px solid var(--ui-shadow);
+	border-bottom: 1px solid var(--border-secondary);
 }
 
 /*#omni .results ui-block.active {*/
@@ -648,11 +699,11 @@ body.showSplitView #leftTabs {
 /*}*/
 
 #omni .results ui-block:hover {
-	background-color: #f5f5f5;
+	background-color: var(--bg-secondary);
 }
 
 #omni .results ui-block.active {
-	color:#fff;
+	color:var(--text-inverted);
 	background: var(--theme);
 	cursor:pointer;
 }
@@ -705,9 +756,9 @@ body.showSplitView #leftTabs {
 	bottom:0;
 	left:0;
 	right:0;
-	width:100%;
-	background: var(--ui-pri-bg);
-	box-shadow: 0 -5px 5px var(--ui-shadow);
+	width:100%; /* The drawer should be full width */
+	background: var(--bg-primary);
+	box-shadow: 0 -5px 5px var(--shadow-color);
 }
 
 #sidebar {
@@ -722,7 +773,7 @@ body.showSplitView #leftTabs {
 	flex-shrink: 0;
     user-select:none;
     -webkit-user-select:none;
-    background: linear-gradient(to bottom, var(--themeDark) 33%, var(--theme));
+    background: linear-gradient(to bottom, var(--theme-dark) 33%, var(--theme));
 }
 
 #sidebar-panels-container {
@@ -748,15 +799,15 @@ body.showSplitView #leftTabs {
     bottom:32px;
     left: 32px; /* 8px offset from left */
     right: 32px; /* 8px offset from right */
-    background-color: var(--dark); /* Dark background */
-    color: #fff; /* White text */
+    background-color: var(--bg-secondary); /* Dark background */
+    color: var(--text-primary); /* White text */
     padding: 6px;
     display: flex;
     justify-content: space-between; /* Space between items */
     align-items: center;
     gap: 6px; /* Space between items */
     z-index: 1000; /* Ensure it's on top */
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2); /* Subtle shadow (changed from bottom to top) */
+    box-shadow: 0 2px 10px var(--shadow-color); /* Subtle shadow (changed from bottom to top) */
     border-radius: 5px; /* Slightly rounded corners */
     border: 1px solid var(--theme);
 }
@@ -768,7 +819,7 @@ body.showSplitView #leftTabs {
 
 .notice-bar button {
     background-color: var(--theme); /* Blue button */
-    color: white;
+    color: var(--text-inverted);
     border: none;
     padding: 8px 15px;
     border-radius: 5px;
@@ -778,7 +829,7 @@ body.showSplitView #leftTabs {
 
 
 .notice-bar button:hover {
-    background-color: var(--themeDark); /* Darker blue on hover */
+    background-color: var(--theme-dark); /* Darker blue on hover */
 }
 
 #sidebar-panels-container {
@@ -832,8 +883,9 @@ ui-sidebar-panel .conversation-area::-webkit-scrollbar-thumb {
 ui-sidebar-panel pre {
 	max-width: 100%;
 	overflow-x: auto;
-	white-space: pre;
-	background-color: rgba(0,0,0, 0.25);
+	white-space: pre; /* The pre element should preserve whitespace. */ 
+	background-color: var(--hljs-bg, var(--bg-code));
+	color: var(--hljs-text, var(--text-primary));
 	border-radius: 8px;
 	padding: 8px;
 }
@@ -873,22 +925,22 @@ ui-sidebar-panel.terminal-panel-container .terminal-containers-wrapper .terminal
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: #222;
+    background-color: var(--bg-terminal);
     padding:2px;
 }
 
 ui-tabbar.tabs-inverted {
-	display: flex;
+	display: flex; /* Tabs should be laid out in a row. */
     overflow-x: auto;
     box-sizing: border-box;
-    border-top: 3px solid var(--themeDark);
-    box-shadow: 0 -5px 10px rgba(0, 0, 0, 0.25);
+    border-top: 3px solid var(--theme-dark);
+    box-shadow: 0 -5px 10px var(--shadow-color);
     z-index: 2;
 }
 
 .conduit-setup-guide .conduit-notice {
-    background-color: rgba(255, 193, 7, 0.15); /* Soft amber */
-    border: 1px solid var(--themeDark);
+    background-color: color-mix(in srgb, var(--color-warning) 15%, transparent);
+    border: 1px solid var(--theme-dark);
     border-radius: 5px;
     padding: 1em;
     margin: 1em 0;
@@ -900,7 +952,7 @@ ui-tabbar.tabs-inverted {
 }
 
 .conduit-setup-guide .conduit-notice.windows-unsupported {
-    background-color: rgba(220, 53, 69, 0.1); /* Soft red */
+    background-color: color-mix(in srgb, var(--color-error) 10%, transparent); /* Soft red */
     border-color: #a12c36;
     color: var(--high);
 }
@@ -916,8 +968,8 @@ ui-tabbar.tabs-inverted {
 }
 
 .install-output {
-    background-color: #222;
-    color: #ccc;
+    background-color: var(--bg-terminal);
+    color: var(--text-secondary);
     padding: 8px;
     border-radius: 4px;
 }
@@ -934,7 +986,7 @@ ui-tabbar.tabs-inverted {
     justify-content: center;
     align-items: center;
     text-align: center;
-    color: var(--mid);
+    color: var(--text-secondary);
 }
 .ai-background-element .caption {
     margin-top: 1em;
@@ -954,7 +1006,7 @@ ui-tabbar.tabs-inverted {
     justify-content: center;
     align-items: center;
     text-align: center;
-    color: var(--mid);
+    color: var(--text-secondary);
 }
 
 .file-list-background-element .caption {
@@ -976,7 +1028,7 @@ ui-tabbar.tabs-inverted {
     justify-content: center;
     align-items: center;
     text-align: center;
-    color: var(--mid);
+    color: var(--text-secondary);
 }
 .terminal-background-element .caption {
     margin-top: 1em;
@@ -990,9 +1042,9 @@ ui-tabbar.tabs-inverted {
     margin-bottom: 1em;
 }
 .loading-spinner {
-    border: 4px solid rgba(255, 255, 255, 0.2);
+    border: 4px solid var(--border-secondary);
     border-radius: 50%;
-    border-top: 4px solid var(--theme);
+    border-top-color: var(--theme);
     width: 24px;
     height: 24px;
     animation: spin 1s linear infinite;
@@ -1006,7 +1058,7 @@ ui-tabbar.tabs-inverted[slim] > ui-tab-item {
 }
 
 ui-tabbar[slim] > ui-tab-item[is-changed] {
-	background:var(--red-soft);
+	background:var(--diff-red-soft);
 }
 
 /* Override to ensure bottom corners are square */

--- a/code-pwa/js/ai-manager.mjs
+++ b/code-pwa/js/ai-manager.mjs
@@ -1229,6 +1229,7 @@ class AIManager {
             }
 
 			const codeElement = pre.querySelector("code") // Get the code element inside pre
+			const isDiff = codeElement && codeElement.classList.contains('language-diff');
 
 			const buttonContainer = new Block()
 
@@ -1238,35 +1239,37 @@ class AIManager {
             }
 			buttonContainer.classList.add("code-buttons")
 
-			// Common buttons for all code blocks
-			const copyButton = new Button()
-			copyButton.classList.add("code-button")
-			copyButton.icon = "content_copy"
-			copyButton.title = "Copy code"
-			copyButton.on("click", () => {
-				const code = codeElement ? codeElement.innerText : pre.innerText; // Use codeElement if exists
-				navigator.clipboard.writeText(code)
-				copyButton.icon = "done"
-				setTimeout(() => {
-					copyButton.icon = "content_copy"
-				}, 1000)
-			})
-			buttonContainer.append(copyButton);
+			if (!isDiff) {
+				// Common buttons for all code blocks
+				const copyButton = new Button()
+				copyButton.classList.add("code-button")
+				copyButton.icon = "content_copy"
+				copyButton.title = "Copy code"
+				copyButton.on("click", () => {
+					const code = codeElement ? codeElement.innerText : pre.innerText; // Use codeElement if exists
+					navigator.clipboard.writeText(code)
+					copyButton.icon = "done"
+					setTimeout(() => {
+						copyButton.icon = "content_copy"
+					}, 1000)
+				})
+				buttonContainer.append(copyButton);
 
-			const insertButton = new Button()
-			insertButton.classList.add("code-button")
-			insertButton.icon = "input"
-			insertButton.title = "Insert into editor"
-			insertButton.on("click", () => {
-				const code = codeElement ? codeElement.innerText : pre.innerText; // Use codeElement if exists
-				const event = new CustomEvent("insert-snippet", { detail: code })
-				window.dispatchEvent(event)
-				insertButton.icon = "done"
-				setTimeout(() => {
-					insertButton.icon = "input"
-				}, 1000)
-			})
-			buttonContainer.append(insertButton);
+				const insertButton = new Button()
+				insertButton.classList.add("code-button")
+				insertButton.icon = "input"
+				insertButton.title = "Insert into editor"
+				insertButton.on("click", () => {
+					const code = codeElement ? codeElement.innerText : pre.innerText; // Use codeElement if exists
+					const event = new CustomEvent("insert-snippet", { detail: code })
+					window.dispatchEvent(event)
+					insertButton.icon = "done"
+					setTimeout(() => {
+						insertButton.icon = "input"
+					}, 1000)
+				})
+				buttonContainer.append(insertButton);
+			}
 
             // Expand/Collapse button
             const expandCollapseButton = new Button();
@@ -1313,7 +1316,7 @@ class AIManager {
 
 
             // NEW: Diff specific handling
-            if (codeElement && codeElement.classList.contains('language-diff')) {
+            if (isDiff) {
                 const originalDiffString = codeElement.textContent; // Get the raw diff content
 
                 // Infer the language from the '+++ b/path/to/file.ext' line in the diff.

--- a/code-pwa/js/elements/panel.mjs
+++ b/code-pwa/js/elements/panel.mjs
@@ -16,7 +16,7 @@ export class Panel extends Block {
 		this.borderHandleSize = 8
 		this.borderHandleVisual = 4
 		this.activeBorder = `${this.borderHandleVisual}px solid var(--theme)`;
-		this.inactiveBorder = `${this.borderHandleVisual}px solid var(--dark)`;
+		this.inactiveBorder = `${this.borderHandleVisual}px solid transparent`;
 		this.active;
 		
 		this.on("pointerleave", (e)=>{

--- a/code-pwa/js/main.mjs
+++ b/code-pwa/js/main.mjs
@@ -558,8 +558,14 @@ const openWorkspace = (() => {
 
 const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
 
+const clearInjectedTheme = () => {
+    // This function is no longer needed as we're not dynamically injecting editor colors
+    // Instead, CSS handles light/dark mode with pre-defined variables.
+};
+
 const execCommandSetDarkMode = (mode) => {
     app.darkmode = mode;
+
     switch (mode) {
         case 'light':
             document.body.classList.remove("darkmode");
@@ -568,7 +574,7 @@ const execCommandSetDarkMode = (mode) => {
             document.body.classList.add("darkmode");
             break;
         case 'system':
-            if (prefersDarkMode.matches) {
+            if (prefersDarkMode.matches) { // This only updates on initial load and system preference change
                 document.body.classList.add("darkmode");
             } else {
                 document.body.classList.remove("darkmode");
@@ -576,7 +582,7 @@ const execCommandSetDarkMode = (mode) => {
             break;
     }
     saveAppConfig();
-    updateThemeAndMode();
+    updateThemeAndMode(false); // Update menus, but don't save again
 };
 
 prefersDarkMode.addEventListener('change', () => {
@@ -593,6 +599,7 @@ const updateThemeAndMode = (doSave = false) => {
 	} else {
 		prettify.setAttribute("disabled", "disabled")
 	}
+
 	if (doSave) saveAppConfig()
 }
 


### PR DESCRIPTION
Remove unstable 'Match Editor' theme option from index.html. Standardize highlight.js colors in main.css to consistently match ace/theme/chrome (light mode) and ace/theme/code (dark mode). Remove all related dynamic Ace theme color extraction logic from main.mjs. Un-bold diff-output.css .add and .remove lines for improved readability.